### PR TITLE
Add endpoint to list all subscribers

### DIFF
--- a/src/endpoints/topic-details.ts
+++ b/src/endpoints/topic-details.ts
@@ -37,26 +37,27 @@ export const getTopicDetails: PushkinRequestHandler<void, TopicDetailsParams> = 
 
 interface TopicSubscriberParams {
   topic_name: string;
-  page?: string;
 }
 
 export const getTopicSubscribers: PushkinRequestHandler<void, TopicSubscriberParams> = async function(req, res, next) {
   try {
-    let pageNumber = 0;
-    if ("page" in req.params) {
-      let parsed = parseInt(req.params.page, 10);
+    let pageNumber = 1;
+    if ("page" in req.query) {
+      let parsed = parseInt(req.query.page, 10);
       if (isNaN(parsed)) {
         throw new Error("Could not parse page number provided");
       }
       pageNumber = parsed;
     }
 
+    let zeroIndexedPageNumber = pageNumber - 1;
+
     let { rows } = await req.db.query(
       `
       SELECT firebase_id from currently_subscribed WHERE topic_id = $1
       OFFSET $2 LIMIT $3
     `,
-      [req.params.topic_name, pageNumber * 1000, 1000]
+      [req.params.topic_name, zeroIndexedPageNumber * 1000, 1000]
     );
 
     let ids = rows.map(r => r.firebase_id);

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,7 @@ export async function createServer(): Promise<Server> {
   // use() on the other hand only runs on requests that have matching routes.
 
   server.use(
+    restify.plugins.queryParser(),
     restify.plugins.bodyParser({
       // by default the body parser adds values to req.params. I don't know why, it makes a lot
       // more sense to separate out req.params and req.body.

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -3,7 +3,7 @@ import { checkForKey, ApiKeyType } from "./security/key-check";
 import { getFirebaseId } from "./endpoints/get-firebase-id";
 import { getSubscribed } from "./endpoints/get-subscribed";
 import { sendMessageToRegistration, sendMessageToTopic, sendMessageToCondition } from "./endpoints/send-message";
-import { getTopicDetails } from "./endpoints/topic-details";
+import { getTopicDetails, getTopicSubscribers } from "./endpoints/topic-details";
 import { getVAPIDKey } from "./endpoints/vapid-key";
 import { healthcheck } from "./endpoints/health-check";
 import { subscribeOrUnsubscribe } from "./endpoints/subscribe";
@@ -19,6 +19,7 @@ export function setRoutes(server: restify.Server) {
 
   server.post("/registrations/:registration_id", checkForKey(ApiKeyType.Admin), sendMessageToRegistration);
   server.get("/topics/:topic_name", checkForKey(ApiKeyType.Admin), getTopicDetails);
+  server.get("/topics/:topic_name/subscribers", checkForKey(ApiKeyType.Admin), getTopicSubscribers);
   server.get("/vapid-key", checkForKey(ApiKeyType.User), getVAPIDKey);
 
   server.get("/healthcheck", healthcheck);

--- a/test/endpoints/topic-details.ts
+++ b/test/endpoints/topic-details.ts
@@ -100,7 +100,7 @@ describe("Topic Details", () => {
     expect(json[0]).to.eq("TEST_USER");
   });
 
-  it.only("Should page this results list correctly", async () => {
+  it("Should page this results list correctly", async () => {
     let values: string[] = [];
     for (let x = 0; x < 1001; x++) {
       values.push(`('TEST_TOPIC','TEST_USER_${x}')`);

--- a/test/endpoints/topic-details.ts
+++ b/test/endpoints/topic-details.ts
@@ -17,7 +17,7 @@ describe("Topic Details", () => {
     await server.stop();
   });
 
-  it("Should show subscribers and unsubscribers", async () => {
+  it("Should show subscriber and unsubscriber totals", async () => {
     let res = await fetch(`http://localhost:3000/topics/TEST_TOPIC`, {
       headers: {
         authorization: Environment.ADMIN_API_KEY
@@ -30,7 +30,7 @@ describe("Topic Details", () => {
     expect(json.subscribers.currentlySubscribed).to.eq(0);
   });
 
-  it("Should reflect subscribes and unsubscribes", async () => {
+  it("Should reflect subscribes and unsubscribes in totals", async () => {
     let sub = subscribeUserNock("TEST_USER", "TEST_TOPIC");
     let unsub = unsubscribeUserNock("TEST_USER", "TEST_TOPIC");
 
@@ -75,5 +75,28 @@ describe("Topic Details", () => {
     expect(json.subscribers.currentlySubscribed).to.eq(0, "Current subscribers should equal 0");
 
     unsub.done();
+  });
+
+  it("Should return a list of subscribed tokens", async () => {
+    let sub = subscribeUserNock("TEST_USER", "TEST_TOPIC");
+    await fetch("http://localhost:3000/topics/TEST_TOPIC/subscribers/TEST_USER", {
+      method: "POST",
+      headers: {
+        authorization: Environment.USER_API_KEY,
+        "content-type": "application/json"
+      }
+    });
+    sub.done();
+
+    let res = await fetch("http://localhost:3000/topics/TEST_TOPIC/subscribers", {
+      headers: {
+        authorization: Environment.ADMIN_API_KEY
+      }
+    });
+
+    let json = await res.json();
+    expect(res.status).to.eq(200);
+    expect(json.length).to.eq(1);
+    expect(json[0]).to.eq("TEST_USER");
   });
 });

--- a/test/endpoints/topic-details.ts
+++ b/test/endpoints/topic-details.ts
@@ -99,4 +99,9 @@ describe("Topic Details", () => {
     expect(json.length).to.eq(1);
     expect(json[0]).to.eq("TEST_USER");
   });
+
+  xit("Should page this results list correctly", () => {
+    // This will be filled in once we have batch insert functionality added. Will
+    // be a nightmare to test otherwise.
+  });
 });

--- a/test/endpoints/topic-details.ts
+++ b/test/endpoints/topic-details.ts
@@ -100,8 +100,32 @@ describe("Topic Details", () => {
     expect(json[0]).to.eq("TEST_USER");
   });
 
-  xit("Should page this results list correctly", () => {
-    // This will be filled in once we have batch insert functionality added. Will
-    // be a nightmare to test otherwise.
+  it.only("Should page this results list correctly", async () => {
+    let values: string[] = [];
+    for (let x = 0; x < 1001; x++) {
+      values.push(`('TEST_TOPIC','TEST_USER_${x}')`);
+    }
+
+    await server.databaseClient.query(
+      "INSERT INTO currently_subscribed (topic_id, firebase_id) VALUES " + values.join(",")
+    );
+
+    let res = await fetch("http://localhost:3000/topics/TEST_TOPIC/subscribers", {
+      headers: {
+        authorization: Environment.ADMIN_API_KEY
+      }
+    });
+
+    let json = await res.json();
+    expect(json.length).to.eq(1000);
+
+    res = await fetch("http://localhost:3000/topics/TEST_TOPIC/subscribers?page=2", {
+      headers: {
+        authorization: Environment.ADMIN_API_KEY
+      }
+    });
+
+    json = await res.json();
+    expect(json.length).to.eq(1);
   });
 });


### PR DESCRIPTION
To address #2, this adds a new endpoint at:

    GET /topics/${topic_name}/subscribers

that returns the Firebase IDs of all subscribers to a topic. It returns in batches of 1000, paging is controlled by adding `page=#` to the query string.