### PR TITLE
Namespace topics for bulk subscribe operations

### DIFF
--- a/src/endpoints/bulk-subscribe.ts
+++ b/src/endpoints/bulk-subscribe.ts
@@ -1,6 +1,7 @@
 import fetch from "node-fetch";
 import * as bunyan from "bunyan";
 import Environment from "../util/env";
+import { namespaceTopic } from "../util/namespace";
 import { FCMBatchOperationResponse } from "../interface/fcm-responses";
 import { PushkinRequestHandler } from "../util/request-handler";
 import { BadRequestError } from "restify-errors";
@@ -8,7 +9,11 @@ import { BadRequestError } from "restify-errors";
 type BatchOperation = "batchAdd" | "batchRemove";
 
 async function sendRequest(operation: BatchOperation, topicName: string, ids: string[], log: bunyan) {
-  log.info({ operation, topicName, numberOfIds: ids.length }, "Sending batch operation to Firebase...");
+  let namespacedTopic = namespaceTopic(topicName);
+  log.info(
+    { operation, namespacedTopic, topicName, numberOfIds: ids.length },
+    "Sending batch operation to Firebase..."
+  );
   let res = await fetch("https://iid.googleapis.com/iid/v1:" + operation, {
     method: "POST",
     headers: {
@@ -16,7 +21,7 @@ async function sendRequest(operation: BatchOperation, topicName: string, ids: st
       "Content-Type": "application/json"
     },
     body: JSON.stringify({
-      to: "/topics/" + topicName,
+      to: "/topics/" + namespacedTopic,
       registration_tokens: ids
     })
   });

--- a/test/endpoints/bulk-subscribe.ts
+++ b/test/endpoints/bulk-subscribe.ts
@@ -18,7 +18,7 @@ export function bulkOperationNock(operation: "batchAdd" | "batchRemove", userIds
     }
   })
     .post(`/iid/v1:${operation}`, {
-      to: `/topics/${topic}`,
+      to: `/topics/${namespaceTopic(topic)}`,
       registration_tokens: userIds.map(u => u.id)
     })
     .reply(200, {


### PR DESCRIPTION
After a bit of investigation, I think the bug with bulk subscription (#6) not working is being caused by not namespacing the topic before sending it to Firebase. 

I was able to subscribe two devices using the bulk methodology by manually putting in the namespaced topic (which is namespaced during the send request) into the [Firebase SDK for Firebase Messaging](https://firebase.google.com/docs/cloud-messaging/admin/manage-topic-subscriptions) and then receive messages to them. 

A comparison between the current code for [bulk subscribe](https://github.com/newsdev/pushkin/pull/5/files#diff-5b49168f25493e4be4b839e1a2fbbbebR10) vs the [individual subscribe]( https://github.com/newsdev/pushkin/blob/list-endpoint/src/endpoints/subscribe.ts#L15) reveals that namespacing the topic before sending it to FIrebase is necessary when managing subscriptions.

The tests were not catching this, as the tests [did not expect the topic to be namespaced](https://github.com/newsdev/pushkin/pull/5/files#diff-7eed5911a4616dd7b555da989c74b71bR21) either. A comparison between this and the [test for individual subscribes](https://github.com/newsdev/pushkin/blob/list-endpoint/test/endpoints/subscribe.ts#L15) reveals that namespacing should be expected for managing subscriptions.