### PR TITLE
allow alternate header for api key

### DIFF
--- a/src/security/key-check.ts
+++ b/src/security/key-check.ts
@@ -28,7 +28,7 @@ export function checkForKey(keyType: ApiKeyType, enforceRestriction: boolean = t
   // function run when the request is received.
 
   return function(req, res, next) {
-    let auth = req.headers.authorization;
+    let auth = req.headers['x-api-key'] || req.headers.authorization;
 
     if (!auth) {
       req.log.warn({ url: req.url }, "Attempt to access endpoint without specifying API key.");


### PR DESCRIPTION
The `Authorization` header is required for IAP authentication and stripped out before being proxied to the backend. It's also required at the application level for key verification. This allows an alternate header (`x-api-key`) to be used to send the key required at the application level.